### PR TITLE
Glob: fix performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Expressive, dynamic, robust CSS. Curly braces and semicolons: optional.
 
 Nib is a popular Stylus package that adds many helpful, basic, utility mixins.
 
-### [Jeet](http://jeet.gs/) 7.1.0
+### [Jeet](http://jeet.gs/) 7.2.0
 
 An advanced -- yet intuitive -- grid system. Very capable, and useful for laying
 out a page without cluttering up HTML with grid classes.
@@ -33,23 +33,23 @@ It's important to remember to include it in your styles, like so:
 @import 'jeet'
 ```
 
-### [Rupture](http://jenius.github.io/rupture/) 0.6.2
+### [Rupture](http://jenius.github.io/rupture/) 0.7.1
 
 Simple media queries for Stylus. Must be imported before use.
 
-### [Typographic](https://github.com/corysimmons/typographic) 2.9.3
+### [Typographic](https://github.com/corysimmons/typographic) 3.0.0
 
 Quick and dirty responsive typography for the rest of us. Offers great selection
 of common font stacks, and several ways to apply them to your document. Must be
 imported before use.
 
-### [Axis](http://axis.netlify.com/) 0.4.3
+### [Axis](http://axis.netlify.com/) 1.0.0
 
 A higher-level Stylus mixin library with lots of extra functionality. Be sure
 not to miss the normalize() mixin. Axis uses and imports Nib, so Nib has been
 removed from this package. This might not require an import statement.
 
-### [Autoprefixer](https://github.com/jenius/autoprefixer-stylus) 0.13.0
+### [Autoprefixer](https://github.com/jenius/autoprefixer-stylus) 0.14.0
 
 An autoprefixer plugin for Stylus. Will also remove unnecessary prefixes if
 there is widespread browser support. It is automatic and does not need to be
@@ -116,7 +116,7 @@ The import syntax from importing files from other packages is curly braces:
 ```javasciprt
 // in procoder:fancy-buttons package's package.js file
 ...
-api.add('styles/buttons.styl', 'client', {isImport: true});
+api.addFiles('styles/buttons.styl', 'client', {isImport: true});
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ Expressive, dynamic, robust CSS. Curly braces and semicolons: optional.
 
 Nib is a popular Stylus package that adds many helpful, basic, utility mixins.
 
-### [Jeet](http://jeet.gs/) 7.2.0
-
-An advanced -- yet intuitive -- grid system. Very capable, and useful for laying
-out a page without cluttering up HTML with grid classes.
-
 It's important to remember to include it in your styles, like so:
 
 ```
-@import 'jeet'
+@import 'nib'
 ```
+
+### [Jeet](http://jeet.gs/) 7.2.0
+
+An advanced -- yet intuitive -- grid system. Very capable, and useful for laying
+out a page without cluttering up HTML with grid classes. Must be imported before use.
 
 ### [Rupture](http://jenius.github.io/rupture/) 0.7.1
 
@@ -47,7 +47,7 @@ imported before use.
 
 A higher-level Stylus mixin library with lots of extra functionality. Be sure
 not to miss the normalize() mixin. Axis uses and imports Nib, so Nib has been
-removed from this package. This might not require an import statement.
+removed from this package. Must be imported before use.
 
 ### [Autoprefixer](https://github.com/jenius/autoprefixer-stylus) 0.14.0
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'coagmano:stylus',
-  version: '1.2.0',
+  version: '1.2.1',
   summary: 'Stylus plugin with plugins from mquandalle:stylus. Compatible with Meteor 1.4 and \'ecmascript\'',
   git: 'https://github.com/coagmano/meteor-stylus.git'
 });
@@ -13,13 +13,13 @@ Package.registerBuildPlugin({
   ],
   npmDependencies: {
     stylus: 'https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449', // fork of 0.54.5
+    glob: '7.1.3',
     nib: '1.1.2',
-    jeet: '7.1.0',
-    rupture: '0.6.2',
-    axis: '0.4.3',
-    typographic: '2.9.3',
-    'autoprefixer-stylus': '0.13.0',
-    glob: '7.1.2',
+    jeet: '7.2.0',
+    rupture: '0.7.1',
+    axis: '1.0.0',
+    typographic: '3.0.0',
+    'autoprefixer-stylus': '0.14.0',
   }
 });
 

--- a/plugin/compile-stylus.js
+++ b/plugin/compile-stylus.js
@@ -223,11 +223,11 @@ class StylusCompiler extends MultiFileCachingCompiler {
 
     // Here is where the stylus module is instantiated and plugins are attached
     let style = stylus(inputFile.getContentsAsString())
-      .use(axis())
       .use(nib())
-      .use(rupture())
       .use(jeet())
-      .use(typographic());
+      .use(rupture({implicit: false})) // https://github.com/jescalan/rupture#usage
+      .use(typographic())
+      .use(axis({implicit: false})); // https://axis.netlify.com/#usage
 
     if (fileOptions.autoprefixer) {
       style = style.use(autoprefixer(fileOptions.autoprefixer));


### PR DESCRIPTION
@coagmano I think this PR addresses the issues you raised in https://github.com/coagmano/meteor-stylus/pull/6#issuecomment-446862256. I’m making sure the plugins are never implicitly loaded (so one would always need to `@import 'rupture'` etc.) and I’m filtering out plugin paths from the lookups. I think this should eliminate all unnecessary path lookups, e.g. for `<plugin path>/<imported file>`. Do you mind trying this out in your bigger app and letting me know how it goes? And if it fails, can you update the example repo accordingly, and give me write access to it?

I can’t figure out how to write a test case for the “local package that exports Stylus” use case as described by @hwillson in https://github.com/meteor/meteor/pull/9272#issuecomment-348249629. Is there a way to have a test local package that can be included inside this package and loaded into Meteor’s testing app during package testing?